### PR TITLE
feat: add sharing button

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+// 
+</script>
+
+<template>
+  <div class="min-h-[100svh] flex flex-col justify-stretch">
+    <NuxtPage />
+    <footer class="mt-auto p-2 text-center text-sm opacity-75 hover:opacity-100">
+      made with ❤️ by <a
+        class="font-semibold hover:underline"
+        href="https://x.com/danielcroe"
+      >
+        @danielcroe
+      </a>
+      &middot;
+      <a
+        class="hover:underline"
+        href="https://github.com/danielroe/firstcommit.is"
+      >
+        edit on GitHub
+      </a>
+    </footer>
+  </div>
+</template>

--- a/pages/[username].vue
+++ b/pages/[username].vue
@@ -1,8 +1,8 @@
 <template>
-  <div class="min-h-screen flex flex-col justify-center">
+  <div class="flex-grow flex flex-col justify-center p-2">
     <main
       v-if="commit"
-      class="p-8 m-2 shadow-md max-w-[500px] w-full mx-auto border-[1px] border-gray-600 rounded-md"
+      class="p-4 md:p-8 shadow-md max-w-[500px] w-full mx-auto border-[1px] border-gray-600 rounded-md"
     >
       <header class="relative flex flex-row items-center gap-4">
         <NuxtTime
@@ -22,7 +22,10 @@
       </header>
       <hr class="my-4">
       <div class="flex flex-row items-center justify-between gap-4">
-        <div class="flex flex-col gap-2 line-clamp-1">
+        <NuxtLink
+          class="flex flex-col gap-2 line-clamp-1" 
+          :href="commit.html_url"
+        >
           <span class="line-clamp-1">{{ commit.commit.message }}</span>
           <span class="text-xs">
             <span class="flex flex-row gap-2">
@@ -34,25 +37,73 @@
               {{ commit.repository.full_name }}
             </span>
           </span>
-        </div>
-        <NuxtLink
-          :href="commit.html_url"
-          class="flex-shrink-0 rounded bg-black text-white text-sm shadow px-3 py-2 flex flex-row gap-2 items-center"
-        >
-          See full commit
         </NuxtLink>
+        <div class="flex flex-row gap-2">
+          <!-- share to twitter url -->
+          <NuxtLink
+            class="flex-shrink-0 rounded border-transparent border-2 bg-black text-white hover:border-black hover:bg-white hover:text-black text-sm shadow px-2 py-1 md:px-3 md:py-2 flex flex-row gap-2 items-center transition-colors"
+            :href="shareLink"
+            @click.prevent="nativeShare"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              class="h-4 w-4"
+              viewBox="0 0 24 24"
+            ><path
+              fill="currentColor"
+              d="m13.12 17.023l-4.199-2.29a4 4 0 1 1 0-5.465l4.2-2.29a4 4 0 1 1 .958 1.755l-4.2 2.29a4.008 4.008 0 0 1 0 1.954l4.2 2.29a4 4 0 1 1-.959 1.755ZM6 14a2 2 0 1 0 0-4a2 2 0 0 0 0 4Zm11-6a2 2 0 1 0 0-4a2 2 0 0 0 0 4Zm0 12a2 2 0 1 0 0-4a2 2 0 0 0 0 4Z"
+            /></svg>
+            Share
+          </NuxtLink>
+        </div>
       </div>
-      <!-- <hr class="my-4"> -->
     </main>
   </div>
 </template>
 
 <script setup lang="ts">
 import 'cal-sans'
+
+definePageMeta({
+  alias: ['/commit/:username']
+})
+
+
 const route = useRoute('username')
 const username = route.params.username
 
 const { data: commit } = await useFetch(`/api/${username}`)
 
-// TODO: show OG image with commit/PR metadata
+useServerSeoMeta({
+  title: 'firstcommit.is - @' + username,
+  description: 'The first commit of ' + username + ' on GitHub',
+  // TODO: show OG image with commit/PR metadata
+  ogImage: commit.value?.author.avatar_url,
+})
+
+const user = useCookie('github-user')
+const message = computed(() => {
+  if (user.value === username) {
+    return `Check out my first commit on GitHub!\n\nhttps://firstcommit.is/${username}`
+  }
+  
+  return `Check out ${username}'s first commit on GitHub.\n\nhttps://firstcommit.is/${username}`
+
+})
+const shareLink = computed(() => `https://twitter.com/intent/tweet?text=${encodeURIComponent(message.value)}`)
+
+async function nativeShare() {
+  try {
+    if (navigator.share) {
+      return await navigator.share({
+        title: 'firstcommit.is',
+        text: message.value,
+        url: `https://firstcommit.is/${username}`,
+      })
+    }
+  } catch {
+    // ignore errors sharing to native share and fall back directly to Twitter
+  }
+  return navigateTo(shareLink.value, { external: true, open: { target: '_blank' } })
+}
 </script>

--- a/server/routes/oauth/github.ts
+++ b/server/routes/oauth/github.ts
@@ -41,5 +41,7 @@ export default defineEventHandler(async event => {
     },
   })
 
+  setCookie(event, 'github-user', ghUser.login)
+
   return await sendRedirect(event, `/${ghUser.login}`)
 })


### PR DESCRIPTION
adds share button which uses `navigator.share` and falls back to native link without JS or if it's unsupported or not in secure context

resolves https://github.com/danielroe/firstcommit.is/issues/5