### PR TITLE
fix: prevent page zooming

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -4,6 +4,13 @@ const resolver = createResolver(import.meta.url)
 
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
+  app: {
+    head: {
+      title: 'firstcommit - find your first commit',
+      charset: 'utf-8',
+      viewport: 'width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0',
+    },
+  },
   modules: ['@nuxtjs/tailwindcss', '@nuxtjs/fontaine', 'nuxt-time', 'nuxt-og-image', '@nuxtjs/plausible'],
   devtools: { enabled: true },
   experimental: { typedPages: true, componentIslands: true },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -6,8 +6,6 @@ const resolver = createResolver(import.meta.url)
 export default defineNuxtConfig({
   app: {
     head: {
-      title: 'firstcommit - find your first commit',
-      charset: 'utf-8',
       viewport: 'width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0',
     },
   },


### PR DESCRIPTION
Title is just a suggestion :) 

The most important imo would be the viewport metadata - on mobile right now the page zooms in when you focus on the search box. This could be fixed with changing the font-size on the search box of course, but this is a simpler solution which lets you have any font-size there that you want.

Sorry I do realize this is a feat and a fix in one PR. I was trigger happy. Let me know if I should do something about that.

Cheers.