### PR TITLE
chore: migrate to pnpm v11

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-shamefully-hoist=true
-strict-peer-dependencies=false

--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
     "typescript": "5.9.3",
     "vue-tsc": "3.2.8"
   },
-  "packageManager": "pnpm@10.33.4"
+  "packageManager": "pnpm@11.1.2"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,8 @@
+allowBuilds:
+  '@parcel/watcher': false
+  esbuild: false
+  unrs-resolver: false
+
+shamefullyHoist: true
+
+strictPeerDependencies: false


### PR DESCRIPTION
### 📚 Description

this migrates us to pnpm v11, and - in particular - to moving to `allowBuilds`